### PR TITLE
E4218327 integrate edit status

### DIFF
--- a/UI/incidents/details.html
+++ b/UI/incidents/details.html
@@ -94,14 +94,19 @@
                         <span class="success" id="commentMessage"></span>
                         <span class="error" id="commentError"></span>
 
-                        <p class="text-orange" id="incident_status" ><b>status: <i>Draft</i></b></p>
+                        <div class="text-orange" id="statusField">status:<b id="incident_status"></b></div>
+                        <button class="showAdmin" id='editStatusBtn'>Edit status</button>
+                        <button class="hide" id='updateStatusBtn' >Save Changes</button>
+                        <button class="hide" id='cancelEditStatusBtn'>Cancel</button>
+                        <span class="success" id="statusMessage"></span>
+                        <span class="error" id="statusError"></span>
 
-                    </div>
+
+                    </div><br/>
 
                     <div id="googleMap" class="map-pct-80"></div>
                     <div class="flex-row-sp-btn">
-                        <a href="../user/edit_incident.html"><i class="fas fa-edit text-white bg-blue border-radius-pct-50 ">
-                        </i> </a>
+
                         <a><i
                                 class="fas fa-trash-alt text-white border-radius-pct-50 bg-red">
                         </i></a>

--- a/UI/static/js/incident_details.js
+++ b/UI/static/js/incident_details.js
@@ -191,7 +191,7 @@ editStatusBtn.onclick = function(){
 
     statusField.innerHTML = `
         <select id="incident_status" required   class="showAdmin">
-          <option value="${originalStatus}.toLowerCase()">${originalStatus}</option>
+          <option value="${originalStatus}">${originalStatus}</option>
           <option value="draft">Draft</option>
           <option value="resolved">Resolved</option>
           <option value="Under Investigation">Under Investigation</option>

--- a/UI/static/js/incident_details.js
+++ b/UI/static/js/incident_details.js
@@ -34,13 +34,12 @@ function getIncident(incidentType, incidentId) {
                 document.getElementById("incident_title").innerHTML = incident.title;
                 document.getElementById("incident_type").innerHTML = "View " + incident.type + " Details page";
                 document.getElementById("incident_comment").innerHTML = incident.comment;
-                document.getElementById("incident_status");
-                document.getElementById("incident_status").innerHTML = incident.status;
                 document.getElementById("created_by").innerHTML = `
                     <img class="bg-blue  img-circle-small" src="../static/img/profile-pics/user1.png">${incident.owner}
                 `;
 
-                document.getElementById("incident_status").innerHTML = `<b>status: <i>${incident.status}</i></b>`;
+                document.getElementById("incident_status").innerHTML =incident.status;
+
                 //Hide the edit comment button if status is not draft
                 if (incident.status !== "Draft") {
                     document.getElementById('editCommentBtn').style.display = 'none';
@@ -74,7 +73,6 @@ function getIncident(incidentType, incidentId) {
 }
 
 function updateComment() {
-    newComment = document.getElementById('incident_comment').innerHTML;
 
     incidentType = params.get('type');
     incidentId = params.get('id');
@@ -173,4 +171,144 @@ function displayUpdateFields(incidentFieldId, updateButtonId, cancelButtonId, ed
 }
 
 
+
 document.getElementById('updateCommentBtn').onclick = updateComment;
+
+let UpdateStatusBtn = document.getElementById('updateStatusBtn');
+let cancelEditStatusBtn = document.getElementById('cancelEditStatusBtn');
+let editStatusBtn = document.getElementById('editStatusBtn');
+let statusField = document.getElementById('statusField');
+
+editStatusBtn.onclick = function(){
+
+   cancelEditStatusBtn.style.display = 'block';
+   UpdateStatusBtn.style.display = 'block';
+   editStatusBtn.style.display = 'none';
+   // save origin value of status
+   sessionStorage.setItem('originalStatus',document.getElementById('incident_status').innerText);
+
+   let originalStatus = sessionStorage.getItem('originalStatus');
+
+    statusField.innerHTML = `
+        <select id="incident_status" required   class="showAdmin">
+          <option value="${originalStatus}.toLowerCase()">${originalStatus}</option>
+          <option value="draft">Draft</option>
+          <option value="resolved">Resolved</option>
+          <option value="Under Investigation">Under Investigation</option>
+          <option value="rejected">Rejected</option>
+        </select>
+    `
+};
+
+
+function cancelEditStatus (){
+
+    cancelEditStatusBtn.style.display = 'none';
+    UpdateStatusBtn.style.display = 'none';
+    editStatusBtn.style.display = 'block';
+
+    // Restore the status to its original value
+    statusField.innerHTML = `
+        status:<b id="incident_status">${sessionStorage.getItem('originalStatus')}</b>
+    `;
+
+    // Remove the original value of status from session storage
+    sessionStorage.removeItem('originalStatus');
+
+}
+cancelEditStatusBtn.onclick =cancelEditStatus;
+
+UpdateStatusBtn.onclick = function(){
+
+    cancelEditStatusBtn.style.display = 'none';
+    UpdateStatusBtn.style.display = 'none';
+    editStatusBtn.style.display = 'block';
+
+    // Restore the status to its original value
+    statusField.innerHTML = `
+        status:<b id="incident_status">${sessionStorage.getItem('originalStatus')}</b>
+    `;
+
+    // Remove the original value of status from session storage
+    sessionStorage.removeItem('originalStatus');
+
+};
+
+
+function updateStatus() {
+
+    incidentType = params.get('type');
+    incidentId = params.get('id');
+    let url = "https://ireporterapiv3.herokuapp.com/api/v2/".concat(incidentType, "/", incidentId, "/status");
+    let newStatus = document.getElementById('incident_status').value;
+
+
+
+    fetch(url, {
+        method: "PATCH",
+        headers: {
+            "content-type": "application/json",
+            "Authorization": authorizationHeader,
+        },
+        body: JSON.stringify({"status": newStatus})
+
+    })
+        .then((response) => response.json())
+        .then((data) => {
+            if (data.status === 200) {
+                UpdateStatusBtn.style.display = 'none';
+                cancelEditStatusBtn.style.display = 'none';
+                editStatusBtn.style.display = 'none';
+
+                // Display the new value of incident record status
+                statusField.innerHTML = `
+                    status:<b id="incident_status">${data['data'][0].status}</b>
+                `;
+                let statusMessage = document.getElementById('statusMessage');
+                statusMessage.style.display = 'block';
+
+                statusMessage.innerHTML = data['data'][0].success;
+                window.setTimeout(function () {
+
+                    statusMessage.style.display = 'none';
+                    editStatusBtn.style.display = 'block';
+
+                }, 3000);
+
+                //Remove origin value of status from memory
+                sessionStorage.removeItem('originalStatus');
+
+
+            } else if (data.status === 400) {
+
+                let statusError = document.getElementById('statusError');
+                statusError.style.display = 'block';
+
+                statusError.innerHTML = data.error;
+                window.setTimeout(function () {
+                    statusError.style.display = 'none';
+                    cancelEditStatus()
+                }, 3000);
+            } else if (data.status === 401) {
+
+
+                // if session is expired
+                alert(data.error);
+                window.setTimeout(function () {
+                    localStorage.removeItem('iReporterToken');
+
+                }, 3000);
+
+            }
+            else {
+
+
+                // if session is expired
+                alert(JSON.stringify(data.error));
+
+            }
+        })
+        .catch((error) => console.log(error.json()));
+}
+
+UpdateStatusBtn.onclick = updateStatus;

--- a/api/models/incident.py
+++ b/api/models/incident.py
@@ -113,6 +113,7 @@ class Incident:
         return self.db.cursor.fetchone()
 
     def update_incident_status(self, inc_id, inc_type, status):
+        status = str(status.strip().lower().title())
         sql = (
             f"UPDATE incidents SET status='{status}' "
             f"WHERE id='{inc_id}' returning id,status;"

--- a/api/models/incident.py
+++ b/api/models/incident.py
@@ -113,7 +113,6 @@ class Incident:
         return self.db.cursor.fetchone()
 
     def update_incident_status(self, inc_id, inc_type, status):
-        status = status.strip().lower().capitalize()
         sql = (
             f"UPDATE incidents SET status='{status}' "
             f"WHERE id='{inc_id}' returning id,status;"


### PR DESCRIPTION
**This pull request implements edit status of a red-flag or intervention record functionality:-**
Logic implemented
- Only the admin user can edit the status of a record
- A non-admin user has no access to this functionality  The button is hidden automatically.
- To edit the status of the record, click on view details, while on the details page, click on the edit status button

**user story** https://www.pivotaltracker.com/epic/show/4218327

**How to test**
- log in  as a non-admin user and view details of a red-flag or interventions, you will notice there is no update status button
- log in as an admin user and view details of a red-flag or interventions. Try editing the status of a red-flag or intervention record.

**Links**
- UI :  https://kalsmic.github.io/iReporterApi/UI/index.html

**Credentials**
- Username: `arthur2` Password: `Password123`
- Usernmae: `admin` Password: `iReporter123`

@NicholusMuwonge @Rhytah @JamesMudidi @sanya-kenneth @frankopkusianwar @AtamaZack @ManuelDominic @KabohaJeanMark @nadralia @reifred @llwasampijja @richien @Genza999 @3Nakajugo @e-ian @Manorlds-Eaglespark @PatrickMugayaJoel @bisonlou @v1b3m @mwinel @sebbss